### PR TITLE
GUI fixes

### DIFF
--- a/src/scripts/client/data-provider.coffee
+++ b/src/scripts/client/data-provider.coffee
@@ -98,6 +98,7 @@ app.controller 'DataProviderController',
             @$scope.meta = null
             @$scope.fieldDescription = null
             @$scope.field = null
+            @$scope.metaData = null
 
         resetProviderLevelView: () =>
             @resetTableLevelView()

--- a/src/scripts/server/cache_handler.coffee
+++ b/src/scripts/server/cache_handler.coffee
@@ -20,13 +20,16 @@ class CacheHandler
     @set: (key, value) =>
         if not @_cache?
             @_createCache()
-        @_cache.set key, value
+        @_cache.set key, JSON.stringify value
         return
 
     @get: (key) =>
         if not @_cache?
             return null
-        return @_cache.get key
+        ret = (@_cache.get key)?[key]
+        if ret?
+            ret = JSON.parse ret
+        return ret
 
     @_onNewCacheTTL: (ttl) =>
         @_cacheTTL = ttl

--- a/src/scripts/server/meta_data_handler.coffee
+++ b/src/scripts/server/meta_data_handler.coffee
@@ -19,8 +19,8 @@ class MetadataHandler
             cacheKey = @_getCacheKey provider, tableListRequest
             cachedResponse = CacheHandler.get cacheKey
 
-            if Object.keys(cachedResponse).length isnt 0
-                metadata = cachedResponse[cacheKey]
+            if cachedResponse?
+                metadata = cachedResponse
                 result = @_processTableListResponse metadata, search, from, to, filterList
                 onReady result
             else
@@ -40,8 +40,8 @@ class MetadataHandler
 
             cacheKey = @_getCacheKey provider, tableMetadataRequest
             cachedResponse = CacheHandler.get cacheKey
-            if Object.keys(cachedResponse).length isnt 0
-                onReady cachedResponse[cacheKey]
+            if cachedResponse?
+                onReady cachedResponse
             else
                 metadataConnection = MetadataConnection.createInstance Endpoints.getMetadataAddress provider
                 metadataConnection.getMetadata tableMetadataRequest, (metadata) =>

--- a/test/metadata_handler_test.coffee
+++ b/test/metadata_handler_test.coffee
@@ -231,8 +231,6 @@ describe "MetadataHandler", ->
             FILTERLIST = []
             KEY = "key"
             VALUE = "value"
-            DATA = {}
-            DATA[KEY] = VALUE
             RESULT = "result"
             REQUEST = "req"
 
@@ -243,7 +241,7 @@ describe "MetadataHandler", ->
             _getCacheKeyStub = sandbox.stub handler, "_getCacheKey"
             _getCacheKeyStub.returns KEY
             cacheHandlerGetStub = sandbox.stub CacheHandler, "get"
-            cacheHandlerGetStub.returns DATA
+            cacheHandlerGetStub.returns VALUE
             _processTableListResponseStub = sandbox.stub handler, "_processTableListResponse"
             _processTableListResponseStub.returns RESULT
 
@@ -285,7 +283,7 @@ describe "MetadataHandler", ->
             _getCacheKeyStub = sandbox.stub handler, "_getCacheKey"
             _getCacheKeyStub.returns KEY
             cacheHandlerGetStub = sandbox.stub CacheHandler, "get"
-            cacheHandlerGetStub.returns {}
+            cacheHandlerGetStub.returns null
             conn = sinon.createStubInstance MetadataConnection
             endpointsGetMetaDataAddressStub = sandbox.stub Endpoints, "getMetadataAddress"
             endpointsGetMetaDataAddressStub.returns ADDRESSES
@@ -338,7 +336,7 @@ describe "MetadataHandler", ->
             _getCacheKeyStub = sandbox.stub handler, "_getCacheKey"
             _getCacheKeyStub.returns KEY
             cacheHandlerGetStub = sandbox.stub CacheHandler, "get"
-            cacheHandlerGetStub.returns {}
+            cacheHandlerGetStub.returns null
             conn = sinon.createStubInstance MetadataConnection
             endpointsGetMetaDataAddressStub = sandbox.stub Endpoints, "getMetadataAddress"
             endpointsGetMetaDataAddressStub.returns ADDRESSES
@@ -376,8 +374,6 @@ describe "MetadataHandler", ->
             TABLE = "table"
             KEY = "key"
             VALUE = "value"
-            DATA = {}
-            DATA[KEY] = VALUE
             RESULT = "result"
             REQUEST = "req"
 
@@ -388,7 +384,7 @@ describe "MetadataHandler", ->
             _getCacheKeyStub = sandbox.stub handler, "_getCacheKey"
             _getCacheKeyStub.returns KEY
             cacheHandlerGetStub = sandbox.stub CacheHandler, "get"
-            cacheHandlerGetStub.returns DATA
+            cacheHandlerGetStub.returns VALUE
             _processTableListResponseStub = sandbox.stub handler, "_processTableListResponse"
             _processTableListResponseStub.returns RESULT
 
@@ -427,7 +423,7 @@ describe "MetadataHandler", ->
             _getCacheKeyStub = sandbox.stub handler, "_getCacheKey"
             _getCacheKeyStub.returns KEY
             cacheHandlerGetStub = sandbox.stub CacheHandler, "get"
-            cacheHandlerGetStub.returns {}
+            cacheHandlerGetStub.returns null
             conn = sinon.createStubInstance MetadataConnection
             endpointsGetMetaDataAddressStub = sandbox.stub Endpoints, "getMetadataAddress"
             endpointsGetMetaDataAddressStub.returns ADDRESSES
@@ -474,7 +470,7 @@ describe "MetadataHandler", ->
             _getCacheKeyStub = sandbox.stub handler, "_getCacheKey"
             _getCacheKeyStub.returns KEY
             cacheHandlerGetStub = sandbox.stub CacheHandler, "get"
-            cacheHandlerGetStub.returns {}
+            cacheHandlerGetStub.returns null
             conn = sinon.createStubInstance MetadataConnection
             endpointsGetMetaDataAddressStub = sandbox.stub Endpoints, "getMetadataAddress"
             endpointsGetMetaDataAddressStub.returns ADDRESSES


### PR DESCRIPTION
- FIXED: Right column was not refreshed if another table or provider was selected.
- FIXED: Field properties were displayed only if the was not server from cache.

The fix for cache is quick and dirty. We should look for a more robust, fast and fail-safe in-memory cache solution.